### PR TITLE
Add new RM Pro + device model

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ Broadlink.prototype.genDevice = function (devtype, host, mac){
         dev = new device(host,mac);
         dev.rm(true);
         return dev;;
+    }else if(devtype == 0x27a9){ // RM3 Pro Plus (model RM 3422)
+        dev = new device(host,mac);
+        dev.rm(true);
+        return dev;;
     }else{
       return null;
     }


### PR DESCRIPTION
Bought a RM pro + yesterday on amazon and tried to setup.
Had no luck in recognizing my device with your project.
Added little debug code and saw that devtype reports back with 10153.
That looks like a new device type to me