### PR TITLE
Fix missing devices in discovering

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,10 +141,11 @@ Broadlink.prototype.discover = function(){
             this.devices = {};
         }
 
-        if(!this.devices[mac]){
+        var key = mac.toString('hex');
+        if(!this.devices[key]){
             var dev =  this.genDevice(devtype, host, mac);
             if (dev) {
-              this.devices[mac] = dev;
+              this.devices[key] = dev;
               dev.on("deviceReady", () => { this.emit("deviceReady", dev); });
               dev.auth();
             }


### PR DESCRIPTION
Use a string instead of a Buffer as a key of the devices.

Thanks to Mr./Ms. [467] and [485] in a Japanese anonymous BBS.

[467]: http://mevius.5ch.net/test/read.cgi/google/1517544832/467
[485]: http://mevius.5ch.net/test/read.cgi/google/1517544832/485