### PR TITLE
A new ID for Mini 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 // RM Devices (without RF support)
 const rmDeviceTypes = {};
 rmDeviceTypes[parseInt(0x2737, 16)] = 'Broadlink RM Mini';
+rmDeviceTypes[parseInt(0x27c2, 16)] = 'Broadlink RM Mini 3';
 rmDeviceTypes[parseInt(0x273d, 16)] = 'Broadlink RM Pro Phicomm';
 rmDeviceTypes[parseInt(0x2712, 16)] = 'Broadlink RM2';
 rmDeviceTypes[parseInt(0x2783, 16)] = 'Broadlink RM2 Home Plus';


### PR DESCRIPTION
I just bought a new RM Mini 3 (firmware ver. 40) and it reports the ID in the above code change. 
I tested both code learning and emitting and it works just fine after the local edit.
I see there is another active pull request which states it is for Mini 3, but the IDs are different