### PR TITLE
Added variant device type for Broadlink RM Mini

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 // RM Devices (without RF support)
 const rmDeviceTypes = {};
 rmDeviceTypes[parseInt(0x2737, 16)] = 'Broadlink RM Mini';
+rmDeviceTypes[parseInt(0x27c2, 16)] = 'Broadlink RM Mini'; // Some kind of Mini variant, works just the same as the 0x2737 model
 rmDeviceTypes[parseInt(0x273d, 16)] = 'Broadlink RM Pro Phicomm';
 rmDeviceTypes[parseInt(0x2712, 16)] = 'Broadlink RM2';
 rmDeviceTypes[parseInt(0x2783, 16)] = 'Broadlink RM2 Home Plus';


### PR DESCRIPTION
I have one Broadlink RM Mini which has the existing device type identifier 0x2737, but then purchased another and found it did not work. Upon reviewing the logs of homebridge, I discovered it had a different ID, and added it manually to index.js and it has been working flawlessly for a while.

Not sure how prevelant this device ID is, but it's real and out there.